### PR TITLE
Replace vscode-json-languageserver-bin with vscode-json-languageserver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,9 +52,9 @@
       }
     },
     "jsonc-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-1.0.3.tgz",
-      "integrity": "sha512-hk/69oAeaIzchq/v3lS50PXuzn5O2ynldopMC+SWBql7J2WtdptfB9dy8Y7+Og5rPkTCpn83zTiO8FMcqlXJ/g=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.0.tgz",
+      "integrity": "sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA=="
     },
     "ms": {
       "version": "2.0.0",
@@ -62,107 +62,81 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "request-light": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.2.4.tgz",
-      "integrity": "sha512-pM9Fq5jRnSb+82V7M97rp8FE9/YNeP2L9eckB4Szd7lyeclSIx02aIpPO/6e4m6Dy31+FBN/zkFMTd2HkNO3ow==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.2.5.tgz",
+      "integrity": "sha512-eBEh+GzJAftUnex6tcL6eV2JCifY0+sZMIUpUPOVXbs2nV5hla4ZMmO3icYKGuGVuQ2zHE9evh4OrRcH4iyYYw==",
       "requires": {
         "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1",
-        "vscode-nls": "^4.0.0"
-      },
-      "dependencies": {
-        "vscode-nls": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.1.tgz",
-          "integrity": "sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A=="
-        }
+        "https-proxy-agent": "^2.2.3",
+        "vscode-nls": "^4.1.1"
       }
     },
-    "vscode-json-languageserver-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageserver-bin/-/vscode-json-languageserver-bin-1.0.1.tgz",
-      "integrity": "sha512-WU+Ks0OEo1c4pgFUA4gIockhzlRqWqSRL2NXHOCtYhJnuIqfrNgSyECZC+nCMyn/CnzpPuQQjzC74GWlIRXnZQ==",
+    "vscode-json-languageserver": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageserver/-/vscode-json-languageserver-1.2.2.tgz",
+      "integrity": "sha512-oHOFcYJrWFTpS8fz6yRywHw7qNzuOvwhe4ocpwGxTWFvvTZWCXeGhpX6XO6OXh53Aad69qIKWEflza3/N/0h2A==",
       "requires": {
-        "jsonc-parser": "^1.0.0",
-        "request-light": "^0.2.1",
-        "vscode-json-languageservice": "^3.0.1",
-        "vscode-languageserver": "^3.5.0",
-        "vscode-nls": "^2.0.2",
-        "vscode-uri": "^1.0.1"
+        "jsonc-parser": "^2.1.1",
+        "request-light": "^0.2.4",
+        "vscode-json-languageservice": "^3.3.5",
+        "vscode-languageserver": "^6.0.0-next.1",
+        "vscode-nls": "^4.1.1",
+        "vscode-uri": "^2.0.3"
       }
     },
     "vscode-json-languageservice": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.3.0.tgz",
-      "integrity": "sha512-upq1PhwDItazdtRJ/R7uU0Fgrf9iaYa1xLK4WFLExR0DgbPojd0YgMpfyknVyXGlxsg3fJQ0H7J++QeByXHh9w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.4.11.tgz",
+      "integrity": "sha512-26Qv1SFp6x3XmCqU1BRceRsSKRO3xkQa6/K8ziSRt52/LQPiw5ipSxlGVSlzIoi5LCmQVEqUajhiVEMNlFXhNw==",
       "requires": {
-        "jsonc-parser": "^2.1.0",
-        "vscode-languageserver-types": "^3.15.0-next.2",
+        "jsonc-parser": "^2.2.0",
+        "vscode-languageserver-textdocument": "^1.0.0-next.5",
+        "vscode-languageserver-types": "^3.15.0-next.9",
         "vscode-nls": "^4.1.1",
-        "vscode-uri": "^2.0.1"
-      },
-      "dependencies": {
-        "jsonc-parser": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.1.0.tgz",
-          "integrity": "sha512-n9GrT8rrr2fhvBbANa1g+xFmgGK5X91KFeDwlKQ3+SJfmH5+tKv/M/kahx/TXOMflfWHKGKqKyfHQaLKTNzJ6w=="
-        },
-        "vscode-nls": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.1.tgz",
-          "integrity": "sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A=="
-        },
-        "vscode-uri": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.0.3.tgz",
-          "integrity": "sha512-4D3DI3F4uRy09WNtDGD93H9q034OHImxiIcSq664Hq1Y1AScehlP3qqZyTkX/RWxeu0MRMHGkrxYqm2qlDF/aw=="
-        }
+        "vscode-uri": "^2.1.1"
       }
     },
     "vscode-jsonrpc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-      "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
+      "version": "5.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.0-next.5.tgz",
+      "integrity": "sha512-k9akfglxWgr0dtLNscq2uBq48XJwnhf4EaDxn05KQowRwR0DkNML0zeYqFRLtXZe6x5vpL5ppyu4o6GqL+23YQ=="
     },
     "vscode-languageserver": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.1.tgz",
-      "integrity": "sha512-RYUKn0DgHTFcS8kS4VaNCjNMaQXYqiXdN9bKrFjXzu5RPKfjIYcoh47oVWwZj4L3R/DPB0Se7HPaDatvYY2XgQ==",
+      "version": "6.0.0-next.8",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.0.0-next.8.tgz",
+      "integrity": "sha512-NsRKThaAZ6DMX/sHDGxOQ6H4Hjt/GeDSybbFdGc3oCRov4t3gVFnF3kxZ3y5jlvYNYYDdYXfpr8oRzXImBXHwQ==",
       "requires": {
-        "vscode-languageserver-protocol": "3.5.1",
-        "vscode-uri": "^1.0.1"
+        "vscode-languageserver-protocol": "^3.15.0-next.14"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.1.tgz",
-      "integrity": "sha512-1fPDIwsAv1difCV+8daOrJEGunClNJWqnUHq/ncWrjhitKWXgGmRCjlwZ3gDUTt54yRcvXz1PXJDaRNvNH6pYA==",
+      "version": "3.15.0-next.14",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.14.tgz",
+      "integrity": "sha512-xUwwno6Q6RFd2Z2EWV9D3dQlsKPnHyiZMNWq+EC7JJdp2WH1gRlD+KPX4UGRCnJK0WI5omqHV313IESPwRY5xA==",
       "requires": {
-        "vscode-jsonrpc": "3.5.0",
-        "vscode-languageserver-types": "3.5.0"
-      },
-      "dependencies": {
-        "vscode-languageserver-types": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-          "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
-        }
+        "vscode-jsonrpc": "^5.0.0-next.5",
+        "vscode-languageserver-types": "^3.15.0-next.9"
       }
     },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.0-next.5.tgz",
+      "integrity": "sha512-1jp/zAidN/bF/sqPimhBX1orH5G4rzRw63k75TesukJDuxm8yW79ECStWbDSy41BHGOwSGN4M69QFvhancSr5A=="
+    },
     "vscode-languageserver-types": {
-      "version": "3.15.0-next.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.2.tgz",
-      "integrity": "sha512-2JkrMWWUi2rlVLSo9OFR2PIGUzdiowEM8NgNYiwLKnXTjpwpjjIrJbNNxDik7Rv4oo9KtikcFQZKXbrKilL/MQ=="
+      "version": "3.15.0-next.9",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.9.tgz",
+      "integrity": "sha512-Rl/8qJ6932nrHCdPn+9y0x08uLVQaSLRG+U4JzhyKpWU4eJbVaDRoAcz1Llj7CErJGbPr6kdBvShPy5fRfR+Uw=="
     },
     "vscode-nls": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-2.0.2.tgz",
-      "integrity": "sha1-gIUiOAhEuK0VNJmvXDsDkhrqAto="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.1.tgz",
+      "integrity": "sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A=="
     },
     "vscode-uri": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.8.tgz",
-      "integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.1.tgz",
+      "integrity": "sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/sublimelsp/LSP-json#readme",
   "dependencies": {
-    "vscode-json-languageserver-bin": "^1.0.1"
+    "vscode-json-languageserver": "^1.2.2"
   }
 }

--- a/plugin.py
+++ b/plugin.py
@@ -9,7 +9,7 @@ from LSP.plugin.core.settings import ClientConfig, LanguageConfig, read_client_c
 from .schemas import schemas
 
 package_path = os.path.dirname(__file__)
-server_path = os.path.join(package_path, 'node_modules', 'vscode-json-languageserver-bin', 'jsonServerMain.js')
+server_path = os.path.join(package_path, 'node_modules', 'vscode-json-languageserver', 'bin', 'vscode-json-languageserver')
 
 
 def plugin_loaded():


### PR DESCRIPTION
https://www.npmjs.com/package/vscode-json-languageserver-bin hasn't updated for 2 years. And it doesn't allow trailing commas even if using `jsonc` as the `languageId`. (I find this immediately after I switch from vanilla LSP with `vscode-json-languageserver` to LSP-json.

There is also people [questioning](https://github.com/vscode-langservers/vscode-json-languageserver-bin/issues/4) about outdated `vscode-json-languageserver-bin`. I don't understand the point to use a compiled `vscode-json-languageserver-bin` since we are running it under `node` env rather than in a browser. But the most important is, it's quite out-of-date.