### PR TITLE
Fix a schema value for font_size in Preferences.sublime-settings

### DIFF
--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -19,7 +19,7 @@
     },
     "font_size": {
       "markdownDescription": "Point size of the font used in the text area.\n`font_size` is overridden in the platform specific settings file, for example, \"Preferences (Linux).sublime-settings\".\n Because of this, setting it here will have no effect: you must set it in your User File Preferences.",
-      "type": "integer",
+      "type": "number",
       "default": 10
     },
     "font_options": {


### PR DESCRIPTION
This false warning whenever I open my preferences file has bothered me for a while...