### PR TITLE
Encode schema file_patterns internally to simplify authoring

### DIFF
--- a/lsp-json-schemas_extra.json
+++ b/lsp-json-schemas_extra.json
@@ -54,9 +54,9 @@
   {
     "fileMatch": [
       "/Preferences.sublime-settings",
-      "/Preferences%20%28Linux%29.sublime-settings",
-      "/Preferences%20%28OSX%29.sublime-settings",
-      "/Preferences%20%28Windows%29.sublime-settings"
+      "/Preferences (Linux).sublime-settings",
+      "/Preferences (OSX).sublime-settings",
+      "/Preferences (Windows).sublime-settings"
     ],
     "uri": "sublime://schemas/preferences.sublime-settings"
   },


### PR DESCRIPTION
Also fixed an issue where schema list was re-sent to all running
instances of server on new one being created. Only notify the new instance.

Resolves #51