### PR TITLE
Fix schema missing for half of the global preferences

### DIFF
--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -544,20 +544,20 @@
         },
         "auto_complete_triggers": {
           "markdownDescription": "Additional situations to trigger auto complete.",
-          "uniqueItems": true,
           "type": "array",
           "items": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
               "selector": {"type": "string"},
-              "characters": {"type": "string"}
+              "characters": {"type": "string"},
+              "rhs_empty": {"type": "boolean", "default": false}
             },
             "required": ["selector"]
           },
           "default": [
-            {"selector": "text.html", "characters": "<"},
-            {"selector": "punctuation.accessor"}
+            {"selector": "text.html, text.xml", "characters": "<"},
+            {"selector": "punctuation.accessor", "rhs_empty": true}
           ]
         },
         "auto_complete_commit_on_tab": {
@@ -683,7 +683,7 @@
       }
     }
   },
-  "anyOf": [
+  "allOf": [
     {"$ref": "#/definitions/EditorSettings"},
     {
       "properties": {

--- a/schemas/syntax.sublime-settings.json
+++ b/schemas/syntax.sublime-settings.json
@@ -4,7 +4,7 @@
   "allowComments": true,
   "allowTrailingCommas": true,
   "type": "object",
-  "anyOf": [
+  "allOf": [
     {
       "$ref": "sublime://schemas/preferences.sublime-settings#/definitions/EditorSettings"
     },


### PR DESCRIPTION
The global preferences were missing tooltip and validation for all
EditorSettings. This was due to schema for "auto_complete_triggers"
not matching (due to missing the "rhs_empty" property in schema) and
thus the whole "anyOf" schema becoming invalid. Since that item of anyOf
became invalid, the other was tested and matched (because
"additionalProperties" are allowed).

Use "allOf" instead which works correctly for this case.

@AmjadHD 