### PR TITLE
Fixes for color scheme schema

### DIFF
--- a/schemas/sublime-color-scheme.json
+++ b/schemas/sublime-color-scheme.json
@@ -137,7 +137,7 @@
           "format": "color",
           "markdownDescription": "The background color of selected text."
         },
-        "selction_foreground": {
+        "selection_foreground": {
           "type": "string",
           "format": "color",
           "markdownDescription": "A color that will override the scope-based text color of the selection."

--- a/schemas/sublime-color-scheme.json
+++ b/schemas/sublime-color-scheme.json
@@ -317,8 +317,7 @@
               "type": "string",
               "format": "color"
             },
-            "minItems": 2,
-            "uniqueItems": true
+            "minItems": 2
           },
           "background": {
             "type": "string",


### PR DESCRIPTION
* Typo in "selection_foreground"
* Duplicate colors in hashed syntax highlighting are allowed