### PR TITLE
Suggest VSCode schema extension properties in sublime-package.json

### DIFF
--- a/lsp-json-schemas_extra.json
+++ b/lsp-json-schemas_extra.json
@@ -1,5 +1,8 @@
 [
   {
+    "uri": "sublime://schemas/sublime-base"
+  },
+  {
     "fileMatch": ["/*.sublime-build"],
     "uri": "sublime://schemas/sublime-build"
   },
@@ -71,8 +74,5 @@
   {
     "fileMatch": ["/jsconfig.json", "/jsconfig.*.json"],
     "uri": "sublime://schemas/jsconfig"
-  },
-  {
-    "uri": "sublime://schemas/sublime-base"
   }
 ]

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/preferences.sublime-settings",
   "title": "Sublime Text Settings",
   "allowComments": true,

--- a/schemas/sublime-base.json
+++ b/schemas/sublime-base.json
@@ -15,6 +15,39 @@
     },
     "VSCodeSchemaExtensionProperties": {
       "properties": {
+        "defaultSnippets": {
+          "type": "array",
+          "description": "Additional snippets to extend completions with.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "body": {
+                "markdownDescription": "The content to insert on accepting completion, in JSON format.\n\nThe value is processed using snippet rules (see [Sublime Text snippets documentation](http://www.sublimetext.com/docs/completions.html#snippets)).\n\n**Warning**: Make sure that the `$` symbol is escaped when wanting to insert it literally."
+              },
+              "bodyText": {
+                "type": "string",
+                "markdownDescription": "The content to insert on accepting completion, in text format.\n\nThe value is processed using snippet rules (see [Sublime Text snippets documentation](http://www.sublimetext.com/docs/completions.html#snippets)).\n\n**Warning**: Make sure that the `$` symbol is escaped when wanting to insert it literally."
+              },
+              "description": {
+                "type": "string",
+                "description": "The text shown for the documentation field, in plain-text format."
+              },
+              "label": {
+                "type": "string",
+                "description": "The label of the completion item."
+              },
+              "markdownDescription": {
+                "type": "string",
+                "description": "The text shown for the documentation field, in markdown format."
+              }
+            },
+            "oneOf": [
+              { "required": ["body"] },
+              { "required": ["bodyText"] }
+            ]
+          }
+        },
         "deprecationMessage": {
           "type": "string",
           "description": "If set, the property is marked as deprecated and the given message is shown as an explanation."

--- a/schemas/sublime-base.json
+++ b/schemas/sublime-base.json
@@ -16,19 +16,23 @@
     "VSCodeSchemaExtensionProperties": {
       "properties": {
         "deprecationMessage": {
-          "type": "string"
+          "type": "string",
+          "description": "If set, the property is marked as deprecated and the given message is shown as an explanation."
         },
         "enumDescriptions": {
           "type": "array",
+          "description": "Descriptions for enum values.",
           "items": {
             "type": "string"
           }
         },
         "markdownDescription": {
-          "type": "string"
+          "type": "string",
+          "description": "The description in the markdown format."
         },
         "markdownEnumDescriptions": {
           "type": "array",
+          "description": "Descriptions for enum values in the markdown format.",
           "items": {
             "type": "string"
           }

--- a/schemas/sublime-build.json
+++ b/schemas/sublime-build.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-build",
   "title": "Sublime Text Build System",
   "allowComments": true,

--- a/schemas/sublime-color-scheme.json
+++ b/schemas/sublime-color-scheme.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-color-scheme",
   "title": "Sublime Text Color Scheme",
   "allowComments": true,

--- a/schemas/sublime-commands.json
+++ b/schemas/sublime-commands.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-commands",
   "title": "Sublime Text Commands",
   "allowComments": true,

--- a/schemas/sublime-completions.json
+++ b/schemas/sublime-completions.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-completions",
   "title": "Sublime Text Completions",
   "allowComments": true,

--- a/schemas/sublime-keymap.json
+++ b/schemas/sublime-keymap.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-keymap",
   "title": "Sublime Text Keymap",
   "allowComments": true,

--- a/schemas/sublime-macro.json
+++ b/schemas/sublime-macro.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-macro",
   "title": "Sublime Text Macro",
   "allowComments": true,

--- a/schemas/sublime-menu.json
+++ b/schemas/sublime-menu.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-menu",
   "title": "Sublime Text Menu",
   "allowComments": true,

--- a/schemas/sublime-mousemap.json
+++ b/schemas/sublime-mousemap.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-mousemap",
   "title": "Sublime Text Mousemap",
   "allowComments": true,

--- a/schemas/sublime-package-schema.json
+++ b/schemas/sublime-package-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-package-schema",
   "title": "JSON schema for Sublime Text Package",
   "allowComments": true,

--- a/schemas/sublime-project.json
+++ b/schemas/sublime-project.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-project",
   "title": "Sublime Text Project",
   "allowComments": true,

--- a/schemas/sublime-settings.json
+++ b/schemas/sublime-settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-settings",
   "allowComments": true,
   "allowTrailingCommas": true

--- a/schemas/sublime-theme.json
+++ b/schemas/sublime-theme.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/sublime-theme",
   "title": "Sublime Text Theme",
   "allowComments": true,

--- a/schemas/syntax.sublime-settings.json
+++ b/schemas/syntax.sublime-settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "sublime://schemas/sublime-base",
   "$id": "sublime://schemas/syntax.sublime-settings",
   "allowComments": true,
   "allowTrailingCommas": true,


### PR DESCRIPTION
Created a "sublime-base" schema that combines draft-07 and extensions introduced
by VSCode. This makes completions work to suggest things like
"markdownDescription" and a couple of other from
https://github.com/microsoft/vscode-json-languageservice/blob/master/src/jsonSchema.ts

I have not included all as some were not very relevant.