### PR TITLE
Do not prettify json strings in requests/responses

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -48,7 +48,7 @@ class SchemaStore:
             if domain == 'schemas':
                 # Internal schema - 1:1 schema path to file path mapping.
                 schema_path = 'Packages/{}/{}.json'.format(LspJSONPlugin.package_name, schema_path)
-                return ResourcePath(schema_path).read_text()
+                return sublime.encode_value(sublime.decode_value(ResourcePath(schema_path).read_text()), pretty=False)
         print('LSP-json: Unknown schema URI "{}"'.format(uri))
         return None
 
@@ -95,7 +95,7 @@ class SchemaStore:
                 file_patterns = s.get('file_patterns')
                 schema_content = s.get('schema')
                 uri = schema_content.get('$id') or 'sublime://settings/{}'.format(i)
-                self._schema_uri_to_content[uri] = sublime.encode_value(schema_content)
+                self._schema_uri_to_content[uri] = sublime.encode_value(schema_content, pretty=False)
                 self._register_schemas([{'fileMatch': file_patterns, 'uri': uri}])
                 if file_patterns:
                     for pattern in file_patterns:
@@ -119,7 +119,7 @@ class SchemaStore:
                     'settings': schema,
                 },
             }
-            self._schema_uri_to_content[schema_uri] = sublime.encode_value(schema_content)
+            self._schema_uri_to_content[schema_uri] = sublime.encode_value(schema_content, pretty=False)
             self._register_schemas([{'fileMatch': ['/*.sublime-project'], 'uri': schema_uri}])
 
     def _load_syntax_schemas(self, global_preferences_schemas: List[Any]) -> None:
@@ -145,7 +145,7 @@ class SchemaStore:
                     'type': 'object',
                 }
                 schema_content.update(schema)
-                self._schema_uri_to_content[schema_uri] = sublime.encode_value(schema_content)
+                self._schema_uri_to_content[schema_uri] = sublime.encode_value(schema_content, pretty=False)
                 self._register_schemas([{'fileMatch': file_patterns, 'uri': schema_uri}])
 
     def _parse_schema(self, resource: ResourcePath) -> Any:


### PR DESCRIPTION
This makes my RPC logs somewhat more insightful, e.g.

```
::  -> LSP-json json/schemaAssociations: <params with 56392 characters>
:: <-- LSP-json vscode/content(0): sublime://schemas/sublime-base
:: >>> LSP-json 0: {"$id": "sublime://schemas/sublime-base", "$ref": "#/definitions/VSCodeSchemaExtensionRoot", "$schema": "http://json-schema.org/draft-07/schema#", "definitions": {"VSCodeSchemaExtensionProperties": {"properties": {"additionalItems": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}, "additionalProperties": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}, "allOf": {"$ref": "#/definitions/schemaArray"}, "anyOf": {"$ref": "#/definitions/schemaArray"}, "defaultSnippets": {"description": "Additional snippets to extend completions with.", "items": {"additionalProperties": false, "oneOf": [{"required": ["body"]}, {"required": ["bodyText"]}], "properties": {"body": {"markdownDescription": "The content to insert on accepting completion, in JSON format.\n\nThe value is processed using snippet rules (see [Sublime Text snippets documentation](http://www.sublimetext.com/docs/completions.html#snippets)).\n\n**Warning**: Make sure that the `$` symbol is escaped when wanting to insert it literally."}, "bodyText": {"markdownDescription": "The content to insert on accepting completion, in text format.\n\nThe value is processed using snippet rules (see [Sublime Text snippets documentation](http://www.sublimetext.com/docs/completions.html#snippets)).\n\n**Warning**: Make sure that the `$` symbol is escaped when wanting to insert it literally.", "type": "string"}, "description": {"description": "The text shown for the documentation field, in plain-text format.", "type": "string"}, "label": {"description": "The label of the completion item.", "type": "string"}, "markdownDescription": {"description": "The text shown for the documentation field, in markdown format.", "type": "string"}}, "type": "object"}, "type": "array"}, "definitions": {"additionalProperties": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}}, "deprecationMessage": {"description": "If set, the property is marked as deprecated and the given message is shown as an explanation.", "type": "string"}, "else": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}, "enumDescriptions": {"description": "Descriptions for enum values.", "items": {"type": "string"}, "type": "array"}, "if": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}, "items": {"anyOf": [{"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}, {"$ref": "#/definitions/schemaArray"}]}, "markdownDescription": {"description": "The description in the markdown format.", "type": "string"}, "markdownEnumDescriptions": {"description": "Descriptions for enum values in the markdown format.", "items": {"type": "string"}, "type": "array"}, "not": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}, "oneOf": {"$ref": "#/definitions/schemaArray"}, "patternProperties": {"additionalProperties": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}}, "properties": {"additionalProperties": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}}, "propertyNames": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}, "then": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}}}, "VSCodeSchemaExtensionRoot": {"allOf": [{"$ref": "http://json-schema.org/draft-07/schema#"}, {"$ref": "#/definitions/VSCodeSchemaExtensionProperties"}]}, "schemaArray": {"items": {"$ref": "#/definitions/VSCodeSchemaExtensionRoot"}}}, "properties": {"allowComments": {"type": "boolean"}, "allowTrailingCommas": {"type": "boolean"}}}
```