### PR TITLE
Fix build system "syntax" key pattern

### DIFF
--- a/schemas/sublime-build.json
+++ b/schemas/sublime-build.json
@@ -116,7 +116,7 @@
     "syntax": {
       "markdownDescription": "A string specifying the syntax file to use to highlight the build system output panel.\nExample: `\"Packages/JavaScript/JSON.sublime-syntax\"`",
       "type": "string",
-      "pattern": "^Packages/.+\\.(sublime-syntax|tmLanguage)"
+      "pattern": "^(([^/]+|Packages/.+)\\.sublime-syntax|Packages/.+\\.(hidden-)?tmLanguage)$"
     }
   }
 }


### PR DESCRIPTION
All `sublime-...` files may be assigned as file name only value as the basic idea is to have unique file names already. Path part is therefore optional to enforce usage of certain files.

The path is crucial for TextMate values (e.g. `tmLanguage` or `hidden-tmLanguage`) though.