### PR TITLE
Fix: Use ${node_bin} for the node binary

### DIFF
--- a/LSP-json.sublime-settings
+++ b/LSP-json.sublime-settings
@@ -1,5 +1,5 @@
 {
-	"command": ["node", "${server_path}", "--stdio"],
+	"command": ["${node_bin}", "${server_path}", "--stdio"],
 	// ST3
 	"languages": [
 		{

--- a/plugin.py
+++ b/plugin.py
@@ -1,8 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from LSP.plugin import DottedDict
 from LSP.plugin import Notification
-from LSP.plugin import Request
-from LSP.plugin.core.typing import Any, Callable, Dict, List, Mapping, Optional
+from LSP.plugin.core.typing import Any, Callable, Dict, List, Optional
 from lsp_utils import ApiWrapperInterface
 from lsp_utils import request_handler
 from lsp_utils import NpmClientHandler
@@ -214,11 +213,6 @@ class LspJSONPlugin(NpmClientHandler, StoreListener):
             text_document = notification.params['textDocument']
             if any((pattern.search(text_document['uri']) for pattern in self._jsonc_patterns)):
                 text_document['languageId'] = 'jsonc'
-
-    def on_pre_server_command(self, command: Mapping[str, Any], done_callback: Callable[[], None]) -> bool:
-        if command['command'] == 'editor.action.triggerSuggest':
-            return True
-        return False
 
     # --- StoreListener ------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
With the latest version of lsp_utils a change was introduced [1] that allows using a locally
managed node runtime instead of the system one. For that to work, the "node" command
needs to use a variable.

[1] https://github.com/sublimelsp/lsp_utils/commit/403345a0c5c15e84802c712044c630a9fb236b9d