### PR TITLE
Add new context keys of 4K builds to the keymap schema.

### DIFF
--- a/schemas/sublime-keymap.json
+++ b/schemas/sublime-keymap.json
@@ -73,11 +73,11 @@
                   "If a panel is visible and has focus",
                   "If the quick panel is visible",
                   "If the overlay currently open has focus",
-                  "The name of the currently focussed overlay",
-                  "If the currently focussed group has multi selected tabs",
-                  "If the currently focussed group has a transient sheet",
+                  "The name of the currently focused overlay",
+                  "If the currently focused group has multi selected tabs",
+                  "If the currently focused group has a transient sheet",
                   "If the word to the immediate left of the cursor can be expanded to a snippet",
-                  "The type of the focussed panel"
+                  "The type of the focused panel"
                 ]
               },
               {

--- a/schemas/sublime-keymap.json
+++ b/schemas/sublime-keymap.json
@@ -44,7 +44,13 @@
                   "panel",
                   "panel_visible",
                   "panel_has_focus",
-                  "overlay_visible"
+                  "overlay_visible",
+                  "overlay_has_focus",
+                  "overlay_name",
+                  "group_has_multiselect",
+                  "group_has_transient_sheet",
+                  "has_snippet",
+                  "panel_type"
                 ],
                 "enumDescriptions": [
                   "If the auto complete dropdown is visible",
@@ -65,7 +71,13 @@
                   "The name of the current panel",
                   "If a panel is visible",
                   "If a panel is visible and has focus",
-                  "If the quick panel is visible"
+                  "If the quick panel is visible",
+                  "If the overlay currently open has focus",
+                  "The name of the currently focussed overlay",
+                  "If the currently focussed group has multi selected tabs",
+                  "If the currently focussed group has a transient sheet",
+                  "If the word to the immediate left of the cursor can be expanded to a snippet",
+                  "The type of the focussed panel"
                 ]
               },
               {


### PR DESCRIPTION
This PR adds newly added context keys of the 4K build series to the keymap schema. 

Note: These aren't in the official documentation yet. There is an open issue for it https://github.com/sublimehq/sublime_text/issues/4063

Notes:
1. I haven't added `is_javadoc` because I don't know what it does as a context key. I have marked the description for it as a TODO in `PackageDev`. 

2. `panel_type` is a new one (not yet added to `PackageDev`), added in 4097. (Will do so in a future PR to it)