### PR TITLE
Fix file_tab_style setting

### DIFF
--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -888,7 +888,7 @@
         },
         "file_tab_style": {
           "description": "Controls the style of file tabs for the Default, Default Dark, and Adaptive themes.",
-          "enum": ["rounded", "squared", "angled"],
+          "enum": ["rounded", "square", "angled"],
           "enumDescriptions": [
             "",
             "",


### PR DESCRIPTION
Reported on discord - https://discord.com/channels/280102180189634562/280157083356233728/849390510367834125

Rename `squared` to `square`, as `square` is the valid enum value.