### PR TITLE
Add new settings introduced in ST 4114 to the preferences schema

### DIFF
--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -855,6 +855,21 @@
           "markdownDescription": "When enabled, clicking on selected text will begin a drag-drop operation.",
           "type": "boolean",
           "default": true
+        },
+        "find_scroll_highlights_limit": {
+          "markdownDescription": "The maximum number of find results to show in the scroll bar. If this number is exceeded no results will be shown. Use `0` to remove this limit.",
+          "type": "integer",
+          "default": 8192
+        },
+        "find_highlight_matches_max_size": {
+          "markdownDescription": "The maximum file size (in bytes) for which the find option **Highlight matches** will highlight matches (affects non-regexp searches). Use `0` to remove this limit.",
+          "type": "integer",
+          "default": 16777216
+        },
+        "find_regex_highlight_matches_max_size": {
+          "markdownDescription": "The maximum file size (in bytes) for which the find option **Highlight matches** will highlight matches (affects regexp searches). Use `0` to remove this limit.",
+          "type": "integer",
+          "default": 1048576
         }
       }
     }
@@ -1241,7 +1256,7 @@
           "markdownDescription": "**Unlisted.** Prints the active view using the given browser as described by [webbrowser.get](https://docs.python.org/3/library/webbrowser.html#webbrowser.get) API. Added in Build 4094.",
           "oneOf": [
             {
-              "type": "null",
+              "type": "null"
             },
             {
               "type": "string"
@@ -1262,21 +1277,6 @@
           "markdownDescription": "The maximum file size (in bytes) after which syntax highlighting will be disabled for files and will be shown as plain text.",
           "type": "integer",
           "default": 16777216
-        },
-        "find_scroll_highlights_limit": {
-          "markdownDescription": "The maximum number of find results to show in the scroll bar. If this number is exceeded no results will be shown. Use `0` to remove this limit.",
-          "type": "integer",
-          "default": 8192
-        },
-        "find_highlight_matches_max_size": {
-          "markdownDescription": "The maximum file size (in bytes) for which the find option **Highlight matches** will highlight matches (affects non-regexp searches). Use `0` to remove this limit.",
-          "type": "integer",
-          "default": 16777216
-        },
-        "find_regex_highlight_matches_max_size": {
-          "markdownDescription": "The maximum file size (in bytes) for which the find option **Highlight matches** will highlight matches (affects regexp searches). Use `0` to remove this limit.",
-          "type": "integer",
-          "default": 1048576
         }
       }
     }

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1267,6 +1267,11 @@
           "markdownDescription": "The maximum number of find results to show in the scroll bar. If this number is exceeded no results will be shown. Use 0 to remove this limit.",
           "type": "integer",
           "default": 8192
+        },
+        "find_highlight_matches_max_size": {
+          "markdownDescription": "The maximum file size (in bytes) for which the find option **Highlight matches** will highlight matches. Use 0 to remove this limit",
+          "type": "integer",
+          "default": 16777216
         }
       }
     }

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1277,6 +1277,11 @@
           "markdownDescription": "The maximum file size (in bytes) after which syntax highlighting will be disabled for files and will be shown as plain text.",
           "type": "integer",
           "default": 16777216
+        },
+        "focus_on_file_drop": {
+          "markdownDescription": "Whether Sublime Text should take focus when a file is dragged & dropped into it. On **Windows**, this is overriden to true in the platform specific settings.",
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1264,17 +1264,17 @@
           "default": 16777216
         },
         "find_scroll_highlights_limit": {
-          "markdownDescription": "The maximum number of find results to show in the scroll bar. If this number is exceeded no results will be shown. Use 0 to remove this limit.",
+          "markdownDescription": "The maximum number of find results to show in the scroll bar. If this number is exceeded no results will be shown. Use `0` to remove this limit.",
           "type": "integer",
           "default": 8192
         },
         "find_highlight_matches_max_size": {
-          "markdownDescription": "The maximum file size (in bytes) for which the find option **Highlight matches** will highlight matches. Use 0 to remove this limit",
+          "markdownDescription": "The maximum file size (in bytes) for which the find option **Highlight matches** will highlight matches (affects non-regexp searches). Use `0` to remove this limit.",
           "type": "integer",
           "default": 16777216
         },
         "find_regex_highlight_matches_max_size": {
-          "markdownDescription": "The maximum file size (in bytes) for which the find option **Regular expression** will highlight matches. Use 0 to remove this limit",
+          "markdownDescription": "The maximum file size (in bytes) for which the find option **Regular expression** will highlight matches (affects regexp searches). Use `0` to remove this limit.",
           "type": "integer",
           "default": 1048576
         }

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1274,7 +1274,7 @@
           "default": 16777216
         },
         "find_regex_highlight_matches_max_size": {
-          "markdownDescription": "The maximum file size (in bytes) for which the find option **Regular expression** will highlight matches (affects regexp searches). Use `0` to remove this limit.",
+          "markdownDescription": "The maximum file size (in bytes) for which the find option **Highlight matches** will highlight matches (affects regexp searches). Use `0` to remove this limit.",
           "type": "integer",
           "default": 1048576
         }

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1272,6 +1272,11 @@
           "markdownDescription": "The maximum file size (in bytes) for which the find option **Highlight matches** will highlight matches. Use 0 to remove this limit",
           "type": "integer",
           "default": 16777216
+        },
+        "find_regex_highlight_matches_max_size": {
+          "markdownDescription": "The maximum file size (in bytes) for which the find option **Regular expression** will highlight matches. Use 0 to remove this limit",
+          "type": "integer",
+          "default": 1048576
         }
       }
     }

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1262,6 +1262,11 @@
           "markdownDescription": "The maximum file size (in bytes) after which syntax highlighting will be disabled for files and will be shown as plain text.",
           "type": "integer",
           "default": 16777216
+        },
+        "find_scroll_highlights_limit": {
+          "markdownDescription": "The maximum number of find results to show in the scroll bar. If this number is exceeded no results will be shown. Use 0 to remove this limit.",
+          "type": "integer",
+          "default": 8192
         }
       }
     }

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -857,7 +857,7 @@
           "default": true
         },
         "find_scroll_highlights_limit": {
-          "markdownDescription": "The maximum number of find results to show in the scroll bar. If this number is exceeded no results will be shown. Use `0` to remove this limit.",
+          "markdownDescription": "The maximum number of find results to show in the scroll bar. If this number is exceeded then no results will be shown. Use `0` to remove this limit.",
           "type": "integer",
           "default": 8192
         },
@@ -1279,12 +1279,12 @@
           "default": 16777216
         },
         "focus_on_file_drop": {
-          "markdownDescription": "Whether Sublime Text should take focus when a file is dragged & dropped into it. On **Windows**, this is overriden to true in the platform specific settings.",
+          "markdownDescription": "Whether Sublime Text should take focus when a file is dragged & dropped into it. On **Windows**, this is overridden to `true` in the platform specific settings.",
           "type": "boolean",
           "default": false
         },
         "remember_layout": {
-          "markdownDescription": "Whether Sublime Text should start with the same layout it was closed with. Only applies when **hot_exit** setting is disabled.",
+          "markdownDescription": "Whether Sublime Text should start with the same layout it was closed with. Only applies when `hot_exit` setting is disabled.",
           "type": "boolean",
           "default": false
         }

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1282,6 +1282,11 @@
           "markdownDescription": "Whether Sublime Text should take focus when a file is dragged & dropped into it. On **Windows**, this is overriden to true in the platform specific settings.",
           "type": "boolean",
           "default": false
+        },
+        "remember_layout": {
+          "markdownDescription": "Whether Sublime Text should start with the same layout it was closed with. Only applies when **hot_exit** setting is disabled.",
+          "type": "boolean",
+          "default": false
         }
       }
     }


### PR DESCRIPTION
This PR adds the 3 new settings introduced in ST 4114 that allows a user to configure the number of matches/file sizes when using certain `Find` options. More details can be seen in the commits. 