### PR TITLE
Update the `sublime_merge_path` setting.

### DIFF
--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1137,7 +1137,11 @@
         },
         "sublime_merge_path": {
           "description": "The path to the Sublime Merge executable. This should only be set if Sublime Merge is not installed in a standard location, such as when using a portable install.",
-          "type": "string",
+          "type": ["null", "string"],
+          "enum": [null, ""],
+          "markdownEnumDescriptions": [
+            "This will hide Sublime Merge related integrations like context/side bar menu items etc."
+          ],
           "default": ""
         },
         "preview_on_click": {

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1140,7 +1140,7 @@
           "type": ["null", "string"],
           "enum": [null, ""],
           "markdownEnumDescriptions": [
-            "This will hide Sublime Merge related integrations like context/side bar menu items etc."
+            "Hides Sublime Merge related integrations like context/side bar menu items etc."
           ],
           "default": ""
         },


### PR DESCRIPTION
This PR updates the `sublime_merge_path` setting, since as of 4116, it can be set to `null` to hide SM integrations in the form of context/side bar menu items.