### PR TITLE
Add new 4127 settings to preferences schema.

### DIFF
--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1301,6 +1301,11 @@
           "markdownDescription": "Whether to open a new tab after the current tab. If `false`, the new tab will be opened at the end.",
           "type": "boolean",
           "default": true
+        },
+        "update_system_recent_files": {
+          "markdownDescription": "Whether the system's native recent files/folders list should be updated by Sublime Text.",
+          "type": "boolean",
+          "default": true
         }
       }
     }

--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -1296,6 +1296,11 @@
           "markdownDescription": "Mac Only: Whether to use the global find clipboard.",
           "type": "boolean",
           "default": true
+        },
+        "open_tabs_after_current": {
+          "markdownDescription": "Whether to open a new tab after the current tab. If `false`, the new tab will be opened at the end.",
+          "type": "boolean",
+          "default": true
         }
       }
     }


### PR DESCRIPTION
This PR adds newly added 4127 settings `open_tabs_after_current` & `update_system_recent_files` to the preferences schema.