### PR TITLE
[Preferences] Update the `dictionary` setting.

### DIFF
--- a/schemas/preferences.sublime-settings.json
+++ b/schemas/preferences.sublime-settings.json
@@ -299,8 +299,17 @@
         },
         "dictionary": {
           "markdownDescription": "Word list to use for spell checking.",
-          "type": "string",
-          "default": "Packages/Language - English/en_US.dic"
+          "oneOf": [
+            {
+              "type": "string",
+              "default": "Packages/Language - English/en_US.dic"
+            },
+            {
+              "type": "array",
+              "items": { "type": "string" },
+              "default": []
+            }
+          ]
         },
         "spelling_selector": {
           "markdownDescription": "Sets which scopes are checked for spelling errors.",


### PR DESCRIPTION
I wanted to do this with the last PR but I forgot. This PR updates the `dictionary` setting. Earlier it was just a string which was a package resource path pointing to the dictionary, but from Build 4123 onward, it can be a list of dictionaries as well.

```json
	// Word list to use for spell checking. May also be a list of dictionaries.
	"dictionary": "Packages/Language - English/en_US.dic",
```