### PR TITLE
Ignore messages.json schema to aviod conflicts with ST packages

### DIFF
--- a/lsp-json-schemas.json
+++ b/lsp-json-schemas.json
@@ -224,6 +224,7 @@
   },
   {
     "fileMatch": [
+      "!/Packages/**/messages.json",
       "/messages.json"
     ],
     "uri": "https://json.schemastore.org/browser.i18n.json"

--- a/lsp-json-schemas.json
+++ b/lsp-json-schemas.json
@@ -224,13 +224,6 @@
   },
   {
     "fileMatch": [
-      "!/Packages/**/messages.json",
-      "/messages.json"
-    ],
-    "uri": "https://json.schemastore.org/browser.i18n.json"
-  },
-  {
-    "fileMatch": [
       "/bsconfig.json"
     ],
     "uri": "https://raw.githubusercontent.com/rescript-lang/rescript-compiler/master/docs/docson/build-schema.json"

--- a/lsp-json-schemas.json
+++ b/lsp-json-schemas.json
@@ -1623,7 +1623,7 @@
     "fileMatch": [
       "/.talismanrc"
     ],
-    "uri": "https://raw.githubusercontent.com/thoughtworks/talisman/main/third-party/schema-store-talismanrc.json"
+    "uri": "https://raw.githubusercontent.com/thoughtworks/talisman/main/examples/schema-store-talismanrc.json"
   },
   {
     "fileMatch": [
@@ -1660,6 +1660,12 @@
       "/testEnvironments.json"
     ],
     "uri": "https://json.schemastore.org/testenvironments.json"
+  },
+  {
+    "fileMatch": [
+      "/turbo.json"
+    ],
+    "uri": "https://turborepo.org/schema.json"
   },
   {
     "uri": "https://json.schemastore.org/traefik-v2-file-provider.json"
@@ -2096,9 +2102,21 @@
   },
   {
     "fileMatch": [
+      "/.markdown-lint-check.json"
+    ],
+    "uri": "https://json.schemastore.org/markdown-lint-check.json"
+  },
+  {
+    "fileMatch": [
       "/*.ndst.json"
     ],
     "uri": "https://s3.eu-central-1.amazonaws.com/files.netin.io/spider-schemas/template.schema.json"
+  },
+  {
+    "fileMatch": [
+      "/*.sw.json"
+    ],
+    "uri": "https://raw.githubusercontent.com/serverlessworkflow/specification/main/schema/workflow.json"
   },
   {
     "uri": "https://json.schemastore.org/unist.json"

--- a/plugin.py
+++ b/plugin.py
@@ -163,7 +163,7 @@ class SchemaStore:
         for schema in schemas:
             file_matches = schema.get('fileMatch')
             if file_matches:
-                schema['fileMatch'] = [quote(fm, safe="/*") for fm in file_matches]
+                schema['fileMatch'] = [quote(fm, safe="/*!") for fm in file_matches]
             self._schema_list.append(schema)
 
     def _on_schemas_changed(self) -> None:

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -26,18 +26,20 @@ def main():
             schema_list.append({'uri': url})
         if file_match:
             file_match = list(filter(lambda pattern: not RE_YAML.search(pattern), schema['fileMatch']))
+            file_match = list(filter(lambda match: not is_ignored(match), file_match))
         if file_match:
             file_match = list(map(to_absolute_pattern, file_match))
-            file_match = fix_edge_cases(file_match)
             schema_list.append({'fileMatch': file_match, 'uri': url})
 
     with open(os.path.join(DIRECTORY, '..', 'lsp-json-schemas.json'), 'w') as f:
         f.write(dumps(schema_list, indent=2))
 
-def fix_edge_cases(file_match):
-    if "/messages.json" in file_match:
-        return ["!/Packages/**/messages.json", *file_match]
-    return file_match
+
+def is_ignored(file_match: str):
+    ignored_schemas = [
+        "messages.json"  # fixes: https://github.com/sublimelsp/LSP-json/issues/109
+    ]
+    return file_match in ignored_schemas
 
 
 if __name__ == '__main__':

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -20,18 +20,24 @@ def main():
     schemas = requests.get('http://schemastore.org/api/json/catalog.json').json()['schemas']
     schema_list = []
     for schema in schemas:
-        fileMatch = schema.get('fileMatch')
+        file_match = schema.get('fileMatch')
         url = schema['url']
-        if not fileMatch:
+        if not file_match:
             schema_list.append({'uri': url})
-        if fileMatch:
-            fileMatch = list(filter(lambda pattern: not RE_YAML.search(pattern), schema['fileMatch']))
-        if fileMatch:
-            fileMatch = list(map(to_absolute_pattern, fileMatch))
-            schema_list.append({'fileMatch': fileMatch, 'uri': url})
+        if file_match:
+            file_match = list(filter(lambda pattern: not RE_YAML.search(pattern), schema['fileMatch']))
+        if file_match:
+            file_match = list(map(to_absolute_pattern, file_match))
+            file_match = fix_edge_cases(file_match)
+            schema_list.append({'fileMatch': file_match, 'uri': url})
 
     with open(os.path.join(DIRECTORY, '..', 'lsp-json-schemas.json'), 'w') as f:
         f.write(dumps(schema_list, indent=2))
+
+def fix_edge_cases(file_match):
+    if "/messages.json" in file_match:
+        return ["!/Packages/**/messages.json", *file_match]
+    return file_match
 
 
 if __name__ == '__main__':

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -10,12 +10,6 @@ DIRECTORY = os.path.dirname(__file__)
 RE_YAML = re.compile(r'\.ya?ml$')
 
 
-def to_absolute_pattern(pattern: str) -> str:
-    if pattern.startswith('/'):
-        return pattern
-    return '/{}'.format(pattern)
-
-
 def main():
     schemas = requests.get('http://schemastore.org/api/json/catalog.json').json()['schemas']
     schema_list = []
@@ -40,6 +34,12 @@ def is_ignored(file_match: str):
         "messages.json"  # fixes: https://github.com/sublimelsp/LSP-json/issues/109
     ]
     return file_match in ignored_schemas
+
+
+def to_absolute_pattern(pattern: str) -> str:
+    if pattern.startswith('/'):
+        return pattern
+    return '/{}'.format(pattern)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR updates the schemas. 9341c8bc1aa03349557968158f5083eb5d419604

This PR should fix #109 13ca3c4a3cb66f270b3dfa7b8bd104780c16d0a6 but ... this still doesn't fix the issue.
The `/messages.json` schema is still applied in Packages folder, even though I added the following string `"!/Packages/**/messages.json"` to explicitly not match that case.

I am not sure how to tell the server to not apply the /messages.json schema if inside /Packages/ directory.
Any pointers are welcome.