### PR TITLE
Support relative file paths in `userSchemas`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ The JSON-Language-Server implements a color provider that adds color decorators 
 
 To load manually created schemas, add those to `userSchemas` configuration in the settings file. See more information in the comments there.
 
+The custom schema entry needs to look like:
+
+```json
+{
+  "fileMatch": [
+    "/my-file.json"
+  ],
+  "uri": "./my-file-schema.json",
+}
+```
+
+The `fileMatch` is an array of file patterns to match against when resolving JSON files to schemas. `*` and `**` can be used as a wildcard. Exclusion patterns can also be defined and start with `!`. A file matches when there is at least one matching pattern and the last matching pattern is not an exclusion pattern.
+
+The `uri` is a URI or a file path to a schema. Can be a relative path (starting with `./`) when defined in a project settings and in that case will be resolved relative to the first project folder.
+
 ### Schemas contributed by Packages
 
 Sublime Text packages can provide schemas for its own settings, or contribute to global ST settings or other configuration files (for example `*.sublime-project` files).

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -112,7 +112,7 @@
                         "properties": {
                           "fileMatch": {
                             "type": "array",
-                            "markdownDescription": "An array of file patterns to match against when resolving JSON files to schemas. `*` and '**' can be used as a wildcard. Exclusion patterns can also be defined and start with '!'. A file matches when there is at least one matching pattern and the last matching pattern is not an exclusion pattern.",
+                            "markdownDescription": "An array of file patterns to match against when resolving JSON files to schemas. `*` and `**` can be used as a wildcard. Exclusion patterns can also be defined and start with `!`. A file matches when there is at least one matching pattern and the last matching pattern is not an exclusion pattern.",
                             "items": {
                               "type": "string",
                               "default": "/myfile.json",
@@ -122,7 +122,7 @@
                           },
                           "uri": {
                             "type": "string",
-                            "description": "A URL or a file path to a schema. Can be a relative path (starting with './') when defined in project settings and in that case will be resolved relative to the first project folder."
+                            "description": "A URL or a file path to a schema. Can be a relative path (starting with `./`) when defined in a project settings and in that case will be resolved relative to the first project folder."
                           }
                         },
                         "required": [

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -112,14 +112,17 @@
                         "properties": {
                           "fileMatch": {
                             "type": "array",
-                            "markdownDescription": "An array of file patterns to match against when resolving JSON files to schemas.\n\n- `*` can be used as a wildcard\n- Exclusion patterns can also be defined and start with a '!'.\n\nA file matches when there is at least one matching pattern and the last matching pattern is not an exclusion pattern.",
+                            "markdownDescription": "An array of file patterns to match against when resolving JSON files to schemas. `*` and '**' can be used as a wildcard. Exclusion patterns can also be defined and start with '!'. A file matches when there is at least one matching pattern and the last matching pattern is not an exclusion pattern.",
                             "items": {
-                              "type": "string"
+                              "type": "string",
+                              "default": "/myfile.json",
+                              "markdownDescription": "A file pattern that can contain '*' and '**' to match against when resolving JSON files to schemas. When beginning with '!', it defines an exclusion pattern."
                             },
+                            "minItems": 1,
                           },
                           "uri": {
                             "type": "string",
-                            "description": "A URL to a schema."
+                            "description": "A URL or a file path to a schema. Can be a relative path (starting with './') when defined in project settings and in that case will be resolved relative to the first project folder."
                           }
                         },
                         "required": [
@@ -132,7 +135,7 @@
                             "label": "User Schema",
                             "body": {
                               "fileMatch": [
-                                "$1"
+                                "${1:/myfile.json}"
                               ],
                               "uri": "$2"
                             }


### PR DESCRIPTION
Resolve relative paths in `userSchemas` and convert to URIs. Relative paths are resolved relative to the first workspace folder.

Resolves #148