### PR TITLE
Add `bun.lock` to default `jsonc.patterns`

### DIFF
--- a/LSP-json.sublime-settings
+++ b/LSP-json.sublime-settings
@@ -45,6 +45,7 @@
 			"/.ember-cli",
 			"/.vscode/*.json",
 			"/babel.config.json",
+			"bun.lock",
 		],
 		"userSchemas": [
 			// {

--- a/LSP-json.sublime-settings
+++ b/LSP-json.sublime-settings
@@ -45,7 +45,7 @@
 			"/.ember-cli",
 			"/.vscode/*.json",
 			"/babel.config.json",
-			"bun.lock",
+			"/bun.lock",
 		],
 		"userSchemas": [
 			// {


### PR DESCRIPTION
Note that currently the language server gives warnings about trailing comma.
Let's follow https://github.com/microsoft/vscode/pull/236012 to see if there be some ways to suppress them.