### PR TITLE
Add sublime config files to default jsonc patterns

### DIFF
--- a/LSP-json.sublime-settings
+++ b/LSP-json.sublime-settings
@@ -46,7 +46,7 @@
 			"/.vscode/*.json",
 			"/babel.config.json",
 			"/bun.lock",
-			".sublime-*"
+			"*.sublime-*"
 		],
 		"userSchemas": [
 			// {


### PR DESCRIPTION
This should improve the sensible defaults setting to enable comments in sublime config files out of the box.