### PR TITLE
refactor: migrate to LspPlugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 .mypy_cache
 temp/

--- a/commands.py
+++ b/commands.py
@@ -1,29 +1,31 @@
 from __future__ import annotations
 
 from LSP.plugin import apply_text_edits
+from LSP.plugin import Error
 from LSP.plugin import LspTextCommand
 from LSP.plugin import Request
 from LSP.plugin import uri_from_view
-from LSP.plugin.core.protocol import DocumentUri
-from LSP.plugin.core.protocol import Error
-from LSP.plugin.core.protocol import FormattingOptions
-from LSP.plugin.core.protocol import TextEdit
 from LSP.plugin.core.views import formatting_options
 from typing import final
+from typing import TYPE_CHECKING
 from typing import TypedDict
 from typing_extensions import override
 import sublime
+import sublime_plugin
 
-JsonSortDocumentParams = TypedDict('JsonSortDocumentParams', {
-    'uri': DocumentUri,
-    'options': FormattingOptions,
-})
+if TYPE_CHECKING:
+    from LSP.protocol import DocumentUri
+    from LSP.protocol import FormattingOptions
+    from LSP.protocol import TextEdit
+
+
+class JsonSortDocumentParams(TypedDict):
+    uri: DocumentUri
+    options: FormattingOptions
 
 
 @final
 class LspJsonSortDocument(LspTextCommand):
-
-    session_name = __package__
 
     @override
     def run(self, _: sublime.Edit) -> None:
@@ -42,3 +44,13 @@ class LspJsonSortDocument(LspTextCommand):
             sublime.message_dialog(str(response))
             return
         apply_text_edits(self.view, response)
+
+
+@final
+class LspJsonAutoCompleteCommand(sublime_plugin.TextCommand):
+
+    @override
+    def run(self, _: sublime.Edit) -> None:
+        self.view.run_command("insert_snippet", {"contents": '"$0"'})
+        # Do auto-complete one tick later, otherwise LSP is not up-to-date with the incremental text sync.
+        sublime.set_timeout(lambda: self.view.run_command("auto_complete"))

--- a/plugin.py
+++ b/plugin.py
@@ -3,74 +3,64 @@ from __future__ import annotations
 from .schema_store import SchemaEntry
 from .schema_store import SchemaStore
 from .schema_store import StoreListener
-from LSP.plugin import DottedDict
+from copy import deepcopy
+from LSP.plugin import ClientNotification
+from LSP.plugin import command_handler
 from LSP.plugin import filename_to_uri
+from LSP.plugin import LspPlugin
 from LSP.plugin import Notification
+from LSP.plugin import OnPreStartContext
 from LSP.plugin import Promise
 from LSP.plugin import request_handler
-from lsp_utils import ApiWrapperInterface
-from lsp_utils import NpmClientHandler
+from lsp_utils import NodeManager
 from pathlib import Path
+from sublime_lib import ResourcePath
 from typing import Any
-from typing import cast
 from typing import final
-from typing import TYPE_CHECKING
 from typing_extensions import override
 import re
-import sublime
-import sublime_plugin
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from LSP.protocol import ExecuteCommandParams
-
-
-def plugin_loaded():
-    LspJSONPlugin.setup()
-
-
-def plugin_unloaded():
-    LspJSONPlugin.cleanup()
 
 
 @final
-class LspJSONPlugin(NpmClientHandler, StoreListener):
-    package_name = str(__package__)
-    server_directory = 'language-server'
-    server_binary_path = str(Path(server_directory, 'out', 'node', 'jsonServerMain.js'))
-    _schema_store = SchemaStore()
+class LspJSONPlugin(LspPlugin, StoreListener):
+    schema_store = SchemaStore()
 
     @classmethod
     @override
-    def required_node_version(cls) -> str:
-        return '>=18'
+    def on_pre_start_async(cls, context: OnPreStartContext) -> None:
+        package_name = cls.plugin_storage_path.name
+        NodeManager.on_pre_start_async(
+            context,
+            cls.plugin_storage_path,
+            ResourcePath('Packages', package_name, 'language-server'),
+            Path('out', 'node', 'jsonServerMain.js'),
+            '>=18',
+        )
 
-    @classmethod
     @override
-    def cleanup(cls) -> None:
-        cls._schema_store.cleanup()
-        super().cleanup()
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._api: ApiWrapperInterface | None = None
-        self._user_schemas: list[SchemaEntry] = []
-        self._jsonc_patterns: list[re.Pattern[str]] = []
         super().__init__(*args, **kwargs)
+        self._jsonc_patterns: list[re.Pattern[str]] = []
 
     @override
-    def on_settings_changed(self, settings: DottedDict) -> None:
-        self._user_schemas = self._resolve_file_paths(cast('list[SchemaEntry]', settings.get('userSchemas')) or [])
-        self._jsonc_patterns = list(map(self._create_pattern_regexp, settings.get('jsonc.patterns') or []))
-        self._schema_store.load_schemas_async()
+    def on_initialize_async(self) -> None:
+        self.schema_store.add_listener(self)
+        self.schema_store.initialize()
 
-    def _resolve_file_paths(self, schemas: list[SchemaEntry]) -> list[SchemaEntry]:
-        if (session := self.weaksession()) and (folders := session.get_workspace_folders()):
-            for schema in schemas:
-                # Filesystem paths are resolved relative to the first workspace folder.
-                if schema['uri'].startswith(('.', '/')):
-                    absolute_path = Path(folders[0].path, schema['uri'])
-                    schema['uri'] = filename_to_uri(str(absolute_path))
-        return schemas
+    @override
+    def on_pre_send_notification_async(self, notification: ClientNotification) -> None:
+        if notification['method'] == 'textDocument/didOpen':
+            text_document = notification['params']['textDocument']
+            if any(pattern.search(text_document['uri']) for pattern in self._jsonc_patterns):
+                text_document['languageId'] = 'jsonc'
+            return
+        if notification['method'] == 'workspace/didChangeConfiguration' and (session := self.weaksession()):
+            jsonc_patterns: list[str] = session.config.settings.get('jsonc.patterns') or []
+            new_patterns = list(map(self._create_pattern_regexp, jsonc_patterns))
+            if self._jsonc_patterns != new_patterns:
+                self._jsonc_patterns = new_patterns
+                self.schema_store.reload_schemas()
+            return
 
     def _create_pattern_regexp(self, pattern: str) -> re.Pattern[str]:
         # This matches handling of patterns in vscode-json-languageservice.
@@ -78,45 +68,34 @@ class LspJSONPlugin(NpmClientHandler, StoreListener):
         escaped = re.sub(r'[\*]', r'.*', escaped)
         return re.compile(escaped + '$')
 
-    @override
-    def on_ready(self, api: ApiWrapperInterface) -> None:
-        self._api = api
-        self._schema_store.add_listener(self)
-
     @request_handler('vscode/content')
     def handle_vscode_content(self, params: tuple[str]) -> Promise[str | None]:
-        return Promise.resolve(self._schema_store.get_schema_for_uri(params[0]))
+        return Promise.resolve(self.schema_store.get_schema_for_uri(params[0]))
 
-    @override
-    def on_pre_send_notification_async(self, notification: Notification[Any]) -> None:
-        if notification.method == 'textDocument/didOpen':
-            params = cast('dict[str, Any]', notification.params)
-            text_document = params['textDocument']
-            if any(pattern.search(text_document['uri']) for pattern in self._jsonc_patterns):
-                text_document['languageId'] = 'jsonc'
-
-    @override
-    def on_pre_server_command(self, command: ExecuteCommandParams, done_callback: Callable[[], None]) -> bool:
-        if command['command'] == 'json.sort':
-            if (session := self.weaksession()) and (view := session.window.active_view()):
-                view.run_command('lsp_json_sort_document')
-            done_callback()
-            return True
-        return False
+    @command_handler('json.sort')
+    def on_json_sort(self, _: list[None] | None) -> Promise[None]:
+        if (session := self.weaksession()) and (view := session.window.active_view()):
+            view.run_command('lsp_json_sort_document')
+        return Promise.resolve(None)
 
     # --- StoreListener ------------------------------------------------------------------------------------------------
 
     @override
     def on_store_changed_async(self, schemas: list[SchemaEntry]) -> None:
-        if self._api:
-            self._api.send_notification('json/schemaAssociations', [schemas + self._user_schemas])
+        if session := self.weaksession():
+            user_schemas: list[SchemaEntry] = deepcopy(session.config.settings.get('userSchemas') or [])
+            if folders := session.get_workspace_folders():
+                for schema in schemas:
+                    # Filesystem paths are resolved relative to the first workspace folder.
+                    if schema['uri'].startswith(('.', '/')):
+                        absolute_path = Path(folders[0].path, schema['uri'])
+                        schema['uri'] = filename_to_uri(str(absolute_path))
+            session.send_notification(Notification('json/schemaAssociations', [schemas + user_schemas]))
 
 
-class LspJsonAutoCompleteCommand(sublime_plugin.TextCommand):
+def plugin_loaded() -> None:
+    LspJSONPlugin.register()
 
-    @override
-    def run(self, _: sublime.Edit) -> None:
-        self.view.run_command("insert_snippet", {"contents": '"$0"'})
-        # Do auto-complete one tick later, otherwise LSP is not up-to-date with
-        # the incremental text sync.
-        sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
+
+def plugin_unloaded() -> None:
+    LspJSONPlugin.unregister()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 pythonVersion = '3.8'
 reportAny = "none"
 reportExplicitAny = "none"
-reportImplicitOverride = "none"
 reportIncompatibleMethodOverride = "none"
 reportMissingModuleSource = "none"
 reportUnannotatedClassAttribute = "none"
@@ -22,6 +21,38 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 # Automatically detect the appropriate line ending.
 line-ending = "auto"
+
+[tool.ruff.lint]
+# Enable preview rules.
+preview = true
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+select = ["ALL"]
+ignore = [
+    "ANN401",  # https://docs.astral.sh/ruff/rules/any-type/
+    "BLE001",  # https://docs.astral.sh/ruff/rules/blind-except/
+    "CPY001",  # https://docs.astral.sh/ruff/rules/missing-copyright-notice/
+    "C901",  # https://docs.astral.sh/ruff/rules/complex-structure/
+    "D100",  # https://docs.astral.sh/ruff/rules/undocumented-public-module/
+    "D101",  # https://docs.astral.sh/ruff/rules/undocumented-public-class/
+    "D102",  # https://docs.astral.sh/ruff/rules/undocumented-public-method/
+    "D103",  # https://docs.astral.sh/ruff/rules/undocumented-public-function/
+    "D104",  # https://docs.astral.sh/ruff/rules/undocumented-public-package/
+    "D107",  # https://docs.astral.sh/ruff/rules/undocumented-public-init/
+    "D203",
+    "D212",
+    "DOC201",  # https://docs.astral.sh/ruff/rules/docstring-missing-returns/
+    "DOC501",  # https://docs.astral.sh/ruff/rules/docstring-missing-exception/
+    "PLC0415",  # https://docs.astral.sh/ruff/rules/import-outside-top-level/
+    "PLR0912",  # https://docs.astral.sh/ruff/rules/too-many-branches/
+    "PLR0913",  # https://docs.astral.sh/ruff/rules/too-many-arguments/
+    "PLR0915",  # https://docs.astral.sh/ruff/rules/too-many-statements/
+    "PLR1702",  # https://docs.astral.sh/ruff/rules/too-many-nested-blocks/
+    "PLR6301",  # https://docs.astral.sh/ruff/rules/no-self-use/
+    "Q000",  # https://docs.astral.sh/ruff/rules/bad-quotes-inline-string/#bad-quotes-inline-string-q000
+    "TID252",  # https://docs.astral.sh/ruff/rules/relative-imports/
+    "TRY002",  # https://docs.astral.sh/ruff/rules/raise-vanilla-class/
+]
 
 [tool.ruff.lint.isort]
 case-sensitive = false

--- a/schema_store.py
+++ b/schema_store.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABCMeta
+from abc import ABC
 from abc import abstractmethod
 from pathlib import Path
 from sublime_lib import ResourcePath
@@ -13,6 +13,7 @@ from typing_extensions import NotRequired
 from typing_extensions import TypeAlias
 from urllib.parse import quote
 from weakref import WeakSet
+import contextlib
 import sublime
 
 PACKAGE_NAME = str(__package__)
@@ -40,7 +41,7 @@ class ContributionSettingsSchema(TypedDict):
     schema: Schema
 
 
-class StoreListener(metaclass=ABCMeta):
+class StoreListener(ABC):
 
     @abstractmethod
     def on_store_changed_async(self, schemas: list[SchemaEntry]) -> None:
@@ -52,13 +53,16 @@ class SchemaStore:
         self._listeners: WeakSet[StoreListener] = WeakSet()
         self._schema_list: list[SchemaEntry] = []
         self._schema_uri_to_content: dict[str, str] = {}
-        self._schemas_loaded: bool = False
-        self._watched_settings: list[sublime.Settings] = []
+        self._initialized: bool = False
+
+    def initialize(self) -> None:
+        if self._initialized:
+            return
+        self._initialized = True
+        self.reload_schemas()
 
     def add_listener(self, listener: StoreListener) -> None:
         self._listeners.add(listener)
-        if self._schemas_loaded:
-            sublime.set_timeout_async(lambda: listener.on_store_changed_async(self._schema_list))
 
     def get_schema_for_uri(self, uri: str) -> str | None:
         if uri in self._schema_uri_to_content:
@@ -69,24 +73,11 @@ class SchemaStore:
             if domain == 'schemas':
                 # Internal schema - 1:1 schema path to file path mapping.
                 schema_path = f'Packages/{PACKAGE_NAME}/{schema_path}.json'
-                return sublime.encode_value(sublime.decode_value(ResourcePath(schema_path).read_text()), pretty=False)
+                return sublime.encode_value(sublime.decode_value(ResourcePath(schema_path).read_text()))
         print(f'{PACKAGE_NAME}: Unknown schema URI "{uri}"')
         return None
 
-    def cleanup(self) -> None:
-        for settings in self._watched_settings:
-            settings.clear_on_change(PACKAGE_NAME)
-
-    def load_schemas_async(self) -> None:
-        if self._schemas_loaded:
-            return
-        settings = sublime.load_settings('sublime-package.json')
-        settings.add_on_change(PACKAGE_NAME, lambda: sublime.set_timeout_async(self._collect_schemas_async))
-        self._watched_settings.append(settings)
-        self._schemas_loaded = True
-        self._collect_schemas_async()
-
-    def _collect_schemas_async(self) -> None:
+    def reload_schemas(self) -> None:
         self._schema_list = []
         self._schema_uri_to_content = {}
         self._load_bundled_schemas()
@@ -95,17 +86,23 @@ class SchemaStore:
         self._load_syntax_schemas(global_preferences_schemas)
         self._on_schemas_changed()
 
+    def _on_schemas_changed(self) -> None:
+        for listener in self._listeners:
+            listener.on_store_changed_async(self._schema_list)
+
     def _load_bundled_schemas(self) -> None:
         for schema in ['lsp-json-schemas_extra.json', 'lsp-json-schemas.json']:
-            resource_path = f'Packages/{PACKAGE_NAME}/{schema}'
-            if schema_list := self._parse_schema(ResourcePath(resource_path), 'list'):
+            if schema_list := self._parse_schema(ResourcePath(f'Packages/{PACKAGE_NAME}/{schema}'), 'list'):
                 self._register_schemas(schema_list)
 
     def _load_package_schemas(self) -> list[Schema]:
         global_preferences_schemas: list[Schema] = []
         for resource in ResourcePath.glob_resources('sublime-package.json'):
-            if (schema := self._parse_schema(resource, 'dict')) and (contributions := schema.get('contributions')) and \
-                    (settings := contributions.get('settings')):
+            if (
+                (schema := self._parse_schema(resource, 'dict'))
+                and (contributions := schema.get('contributions'))
+                and (settings := contributions.get('settings'))
+            ):
                 for s in settings:
                     i = len(self._schema_uri_to_content)
                     if schema_content := s.get('schema'):
@@ -113,16 +110,16 @@ class SchemaStore:
                         self._schema_uri_to_content[uri] = sublime.encode_value(schema_content, pretty=False)
                         file_patterns = s.get('file_patterns', [])
                         self._register_schemas([{'fileMatch': file_patterns, 'uri': uri}])
-                        for pattern in file_patterns:
-                            if pattern == '/Preferences.sublime-settings':
-                                global_preferences_schemas.append(schema_content)
+                        global_preferences_schemas.extend(
+                            schema_content for pattern in file_patterns if pattern == '/Preferences.sublime-settings'
+                        )
         return global_preferences_schemas
 
     def _generate_project_settings_schemas(self, global_preferences_schemas: list[Schema]) -> None:
         """Inject schemas mapped to /Preferences.json into the "settings" object in *.sublime.project schemas."""
         for i, schema in enumerate(global_preferences_schemas):
             schema_uri = f'sublime://auto-generated/sublime-project/{i}'
-            schema_content = {
+            schema_content: dict[str, Any] = {
                 '$schema': 'http://json-schema.org/draft-07/schema#',
                 '$id': schema_uri,
                 'allowComments': True,
@@ -138,10 +135,8 @@ class SchemaStore:
     def _load_syntax_schemas(self, global_preferences_schemas: list[Schema]) -> None:
         """Discover all available syntaxes and maps their file names to schema."""
         syntaxes = []
-        try:
+        with contextlib.suppress(AttributeError):
             syntaxes = sublime.list_syntaxes()
-        except AttributeError:
-            pass
         if file_patterns := [f'/{Path(s.path).stem}.sublime-settings' for s in syntaxes]:
             self._register_schemas([{'fileMatch': file_patterns, 'uri': 'sublime://schemas/syntax.sublime-settings'}])
         if global_preferences_schemas:
@@ -174,7 +169,3 @@ class SchemaStore:
             if file_matches := schema.get('fileMatch'):
                 schema['fileMatch'] = [quote(fm, safe="/*!") for fm in file_matches]
             self._schema_list.append(schema)
-
-    def _on_schemas_changed(self) -> None:
-        for listener in self._listeners:
-            listener.on_store_changed_async(self._schema_list)


### PR DESCRIPTION
First npm-based package to migrate to the `LspPlugin`.

Depends on next LSP release (>2.10.2) and https://github.com/sublimelsp/lsp_utils/pull/170