### PR TITLE
refactor: add dummy handler for json-schema

### DIFF
--- a/LSP-json.sublime-settings
+++ b/LSP-json.sublime-settings
@@ -1,16 +1,4 @@
 {
-	"schemes": [
-		// regular files
-		"file",
-		// in-memory buffers
-		"buffer",
-		// sublime resource files that are not strictly on-disk
-		"res",
-		// set by yaml-language-server when a remote schema is opened
-		"json-schema"
-	],
-	// don't auto-complete in comments and after typing a ",", ":", "{" or "[", and after closing a string
-	"auto_complete_selector": "- comment - punctuation.separator - punctuation.definition.string.end - constant.character.escape - invalid.illegal - punctuation.section.mapping - punctuation.section.sequence",
 	"disabled_capabilities": {
 		// the trigger characters are too blunt, we'll specify auto_complete_selector manually
 		"completionProvider": {
@@ -68,11 +56,22 @@
 	},
 	// The path to the server binary used to start the language server.
 	// Use `auto` for the package to manage (install/update) the server automatically.
-	// NOTE: Change this instead of directly updating `command` - the `${server_path}` variable is dynamically resolved
-	// based on this setting.
+	// NOTE: Change this instead of directly updating `command` - the `${server_path}` variable is dynamically resolved based on this setting.
 	// WARNING: Override at your own risk - using a custom binary can cause compatibility issues with server settings.
 	"server_path": "auto",
 	// Open "Preferences: LSP Utils Settings" from the Command Palette to customize the Node runtime.
 	"command": ["${node_bin}", "${server_path}", "--stdio"],
+	"schemes": [
+		// regular files
+		"file",
+		// in-memory buffers
+		"buffer",
+		// sublime resource files that are not strictly on-disk
+		"res",
+		// set by yaml-language-server when a remote schema is opened
+		"json-schema"
+	],
+	// don't auto-complete in comments and after typing a ",", ":", "{" or "[", and after closing a string
+	"auto_complete_selector": "- comment - punctuation.separator - punctuation.definition.string.end - constant.character.escape - invalid.illegal - punctuation.section.mapping - punctuation.section.sequence",
 	"selector": "source.json"
 }

--- a/plugin.py
+++ b/plugin.py
@@ -12,13 +12,19 @@ from LSP.plugin import Notification
 from LSP.plugin import OnPreStartContext
 from LSP.plugin import Promise
 from LSP.plugin import request_handler
+from LSP.plugin import uri_handler
 from lsp_utils import NodeManager
 from pathlib import Path
 from sublime_lib import ResourcePath
 from typing import Any
 from typing import final
+from typing import TYPE_CHECKING
 from typing_extensions import override
 import re
+
+if TYPE_CHECKING:
+    from LSP.protocol import DocumentUri
+    import sublime
 
 
 @final
@@ -76,6 +82,11 @@ class LspJSONPlugin(LspPlugin, StoreListener):
     def on_json_sort(self, _: list[None] | None) -> Promise[None]:
         if (session := self.weaksession()) and (view := session.window.active_view()):
             view.run_command('lsp_json_sort_document')
+        return Promise.resolve(None)
+
+    @uri_handler('json-schema')
+    def handle_json_schema_uri(self, uri: DocumentUri, _flags: sublime.NewFileFlags) -> Promise[sublime.Sheet | None]:
+        print(f'LSP-json: Unhandled URI: {uri}')  # noqa: T201
         return Promise.resolve(None)
 
     # --- StoreListener ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The handler doesn't do anything because usually LSP can handle those URIs (recognizes line:column format and jump to a location in the file through document links). But there could be cases where LSP is not recognizing the format of the URI in which case it would fall back to plugin. Want to have a notification when that happens.